### PR TITLE
Allow setting bottom bar background color

### DIFF
--- a/lib/bubble_bottom_bar.dart
+++ b/lib/bubble_bottom_bar.dart
@@ -19,6 +19,7 @@ class BubbleBottomBar extends StatefulWidget {
     this.iconSize = 24.0,
     this.borderRadius,
     this.elevation,
+    this.color
   })  : assert(items != null),
         assert(items.length >= 2),
         assert(
@@ -36,6 +37,7 @@ class BubbleBottomBar extends StatefulWidget {
   final double opacity;
   final BorderRadius borderRadius;
   final double elevation;
+  final Color color;
 
   @override
   _BottomNavigationBarState createState() => _BottomNavigationBarState();
@@ -326,7 +328,7 @@ class _BottomNavigationBarState extends State<BubbleBottomBar>
     return Semantics(
       explicitChildNodes: true,
       child: Material(
-          color: Colors.white,
+          color: widget.color != null ? widget.color : Colors.white,
           borderRadius: widget.borderRadius != null
               ? widget.borderRadius
               : BorderRadius.zero,

--- a/lib/bubble_bottom_bar.dart
+++ b/lib/bubble_bottom_bar.dart
@@ -19,7 +19,7 @@ class BubbleBottomBar extends StatefulWidget {
     this.iconSize = 24.0,
     this.borderRadius,
     this.elevation,
-    this.color
+    this.backgroundColor
   })  : assert(items != null),
         assert(items.length >= 2),
         assert(
@@ -37,7 +37,7 @@ class BubbleBottomBar extends StatefulWidget {
   final double opacity;
   final BorderRadius borderRadius;
   final double elevation;
-  final Color color;
+  final Color backgroundColor;
 
   @override
   _BottomNavigationBarState createState() => _BottomNavigationBarState();
@@ -328,7 +328,7 @@ class _BottomNavigationBarState extends State<BubbleBottomBar>
     return Semantics(
       explicitChildNodes: true,
       child: Material(
-          color: widget.color != null ? widget.color : Colors.white,
+          color: widget.backgroundColor != null ? widget.backgroundColor : Colors.white,
           borderRadius: widget.borderRadius != null
               ? widget.borderRadius
               : BorderRadius.zero,


### PR DESCRIPTION
Added a 'color' parameter to the BubbleBottomBar widget:

Example usage -
```dart
          bottomNavigationBar: BubbleBottomBar(
            color: Colors.white,
            opacity: 0.2,
            currentIndex: pageIndex,
            onTap: (int index) => setState((){
              pageIndex = index;
            }),
            borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
            elevation: 8,
            items: <BubbleBottomBarItem>[
              BubbleBottomBarItem(backgroundColor: Colors.red, icon: Icon(Icons.dashboard, color: Colors.black,), activeIcon: Icon(Icons.dashboard, color: Colors.red,), title: Text("Home")),
              BubbleBottomBarItem(backgroundColor: Colors.deepPurple, icon: Icon(Icons.access_time, color: Colors.black,), activeIcon: Icon(Icons.access_time, color: Colors.deepPurple,), title: Text("Logs")),
              BubbleBottomBarItem(backgroundColor: Colors.indigo, icon: Icon(Icons.folder_open, color: Colors.black,), activeIcon: Icon(Icons.folder_open, color: Colors.indigo,), title: Text("Folders")),
              BubbleBottomBarItem(backgroundColor: Colors.green, icon: Icon(Icons.menu, color: Colors.black,), activeIcon: Icon(Icons.menu, color: Colors.green,), title: Text("Menu"))
            ],
          ),
```